### PR TITLE
Fix problem with nexus not handling signing maven-metadata files

### DIFF
--- a/.github/workflows/release_version.yml
+++ b/.github/workflows/release_version.yml
@@ -20,4 +20,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.signingKey }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.signingPassword }}
         with:
-          arguments: publishAllPublicationsToOSSRHRepository -PossrhUsername=${{ secrets.ossrhUsername }} -PossrhPassword=${{ secrets.ossrhPassword }}
+          arguments: publishAllPublicationsToOSSRHRepository -PossrhUsername=${{ secrets.ossrhUsername }} -PossrhPassword=${{ secrets.ossrhPassword }} -Dorg.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Problem we experience when we want to release new version of artifact:
![image](https://user-images.githubusercontent.com/7306664/75962140-7dc64180-5ec3-11ea-9d65-30557b481946.png)
Fix described here:
https://github.com/gradle/gradle/issues/11308