### PR TITLE
Use HTTP/1.1 unless HTTPS scheme is in URL

### DIFF
--- a/src/main/java/com/bisnode/opa/client/OpaClient.java
+++ b/src/main/java/com/bisnode/opa/client/OpaClient.java
@@ -13,7 +13,6 @@ import com.bisnode.opa.client.query.QueryForDocumentRequest;
 import com.bisnode.opa.client.rest.ObjectMapperFactory;
 import com.bisnode.opa.client.rest.OpaRestClient;
 
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.Objects;
 
@@ -77,9 +76,7 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
         public OpaClient build() {
             Objects.requireNonNull(opaConfiguration, "build() called without opaConfiguration provided");
             HttpClient httpClient = HttpClient.newBuilder()
-                    .version("https".equals(URI.create(opaConfiguration.getUrl()).getScheme()) ?
-                            HttpClient.Version.HTTP_2 :
-                            HttpClient.Version.HTTP_1_1)
+                    .version(opaConfiguration.getHttpVersion())
                     .build();
             OpaRestClient opaRestClient = new OpaRestClient(opaConfiguration, httpClient, ObjectMapperFactory.getInstance().create());
             return new OpaClient(new OpaQueryClient(opaRestClient), new OpaDataClient(opaRestClient), new OpaPolicyClient(opaRestClient));

--- a/src/main/java/com/bisnode/opa/client/OpaClient.java
+++ b/src/main/java/com/bisnode/opa/client/OpaClient.java
@@ -13,7 +13,9 @@ import com.bisnode.opa.client.query.QueryForDocumentRequest;
 import com.bisnode.opa.client.rest.ObjectMapperFactory;
 import com.bisnode.opa.client.rest.OpaRestClient;
 
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.util.Objects;
 
 /**
  * Opa client featuring {@link OpaDataApi}, {@link OpaQueryApi} and {@link OpaPolicyApi}
@@ -73,7 +75,12 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
         }
 
         public OpaClient build() {
-            HttpClient httpClient = HttpClient.newHttpClient();
+            Objects.requireNonNull(opaConfiguration, "build() called without opaConfiguration provided");
+            HttpClient httpClient = HttpClient.newBuilder()
+                    .version("https".equals(URI.create(opaConfiguration.getUrl()).getScheme()) ?
+                            HttpClient.Version.HTTP_2 :
+                            HttpClient.Version.HTTP_1_1)
+                    .build();
             OpaRestClient opaRestClient = new OpaRestClient(opaConfiguration, httpClient, ObjectMapperFactory.getInstance().create());
             return new OpaClient(new OpaQueryClient(opaRestClient), new OpaDataClient(opaRestClient), new OpaPolicyClient(opaRestClient));
         }

--- a/src/main/java/com/bisnode/opa/client/OpaConfiguration.java
+++ b/src/main/java/com/bisnode/opa/client/OpaConfiguration.java
@@ -1,6 +1,8 @@
 package com.bisnode.opa.client;
 
 import java.beans.ConstructorProperties;
+import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.Objects;
 
 /**
@@ -8,6 +10,7 @@ import java.util.Objects;
  */
 public final class OpaConfiguration {
     private final String url;
+    private final HttpClient.Version httpVersion;
 
     /**
      * @param url base URL to OPA server, containing protocol, and port (eg. http://localhost:8181)
@@ -15,6 +18,19 @@ public final class OpaConfiguration {
     @ConstructorProperties({"url"})
     public OpaConfiguration(String url) {
         this.url = url;
+        this.httpVersion = "https".equals(URI.create(url).getScheme()) ?
+                HttpClient.Version.HTTP_2 :
+                HttpClient.Version.HTTP_1_1;
+    }
+
+    /**
+     * @param url base URL to OPA server, containing protocol, and port (eg. http://localhost:8181)
+     * @param httpVersion preferred HTTP version to use for the client
+     */
+    @ConstructorProperties({"url", "httpVersion"})
+    public OpaConfiguration(String url, HttpClient.Version httpVersion) {
+        this.url = url;
+        this.httpVersion = httpVersion;
     }
 
     /**
@@ -22,6 +38,16 @@ public final class OpaConfiguration {
      */
     public String getUrl() {
         return this.url;
+    }
+
+    /**
+     * Get HTTP version configured for the client. If not configured will use HTTP2 for "https" scheme
+     * and HTTP1.1 for "http" scheme.
+     *
+     * @return httpVersion configured for use by the client
+     */
+    public HttpClient.Version getHttpVersion() {
+        return this.httpVersion;
     }
 
     @Override


### PR DESCRIPTION
Default HTTP2 configuration adds three extra headers for version upgrade on each request. These are redundant if the server is configured for HTTP.

Before:
```
GET / HTTP/1.1
Connection: Upgrade, HTTP2-Settings
Content-Length: 0
Host: localhost:8181
HTTP2-Settings: AAEAAEAAAAIAAAABAAMAAABkAAQBAAAAAAUAAEAA
Upgrade: h2c
User-Agent: Java-http-client/11.0.5
```

After:
```
GET / HTTP/1.1
Content-Length: 0
Host: localhost:8181
User-Agent: Java-http-client/11.0.5
```