### PR TITLE
Providing CoC, Contributing and minor changes to existing documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[this email](nights-watch@bisnode.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html),
+version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# How to Contribute
+
+### Welcome
+
+First off, thank you for considering contributing to Opa Java Client. It's people like you that make this client such a great library.
+
+Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, they should reciprocate that respect in addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+### What we are looking for
+
+Opa Java Client is an open source project, and we love to receive contributions from our community — you! There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests or writing code which can be incorporated into Opa Java Client itself.
+
+# Ground Rules
+
+Responsibilities
+* Ensure cross-platform compatibility for every change that's accepted. Windows, Mac, Debian & Ubuntu Linux.
+* Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
+* Keep feature versions as small as possible, preferably one new feature per version.
+* Be welcoming to newcomers and encourage diverse new contributors from all backgrounds. See the [Code of Conduct](https://github.com/Bisnode/opa-java-client/blob/master/CODE_OF_CONDUCT.md).
+
+# Getting started
+
+As a rule of thumb, changes are obvious fixes if they do not introduce any new functionality or creative thinking. As long as the change does not affect functionality, some likely examples include the following:
+* Spelling / grammar fixes
+* Typo correction, white space and formatting changes
+* Comment clean up
+* Bug fixes that change default return values or error codes stored in constants
+* Adding logging messages or debugging output
+* Changes to ‘metadata’ files like .gitignore, build scripts, etc.
+* Moving source files from one directory or package to another
+
+For something that is bigger than a few line fix:
+
+1. Create your own fork of the code
+2. Do the changes in your fork
+3. If you like the change and think the project could use it
+     * Be sure you have followed the code style for the project.
+     * Note the Code of Conduct.
+     * Send a pull request.
+
+
+# How to report a bug
+
+If you find a security vulnerability, do NOT open an issue. Email [maintainers](nights-watch@bisnode.com) instead.
+
+
+Any security issues should be submitted directly to [maintainers](nights-watch@bisnode.com)
+In order to determine whether you are dealing with a security issue, ask yourself these two questions:
+* Can I access something that's not mine, or something I shouldn't have access to?
+* Can I disable something for other people?
+
+If the answer to either of those two questions are "yes", then you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, just [email us](nights-watch@bisnode.com).
+ 
+When filing an issue, make sure to answer these five questions:
+
+1. What version of OPA/Java are you using?
+2. What operating system and processor architecture are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+# How to report a Feature Request
+If you find yourself wishing for a feature that doesn't exist in Opa Java Client, you are probably not alone. There are bound to be others out there with similar needs. Many of the features that Opa Java Client has today have been added because our users saw the need. Open an issue on our issues list on GitHub which describes the feature you would like to see, why you need it, and how it should work.
+
+# Code review process
+
+The core team looks at Pull Requests as fast as possible. If there is a need, we can arrange a meeting and elaborate on implementation details.
+After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
+
+## Code, commit message and labeling conventions
+
+### Commit message convention
+
+Please do not provide nondeterministic messages to commits like: "fix vol2", "another fix". 
+From maintainers point of view, there should be one commit for one Pull Request. 
+Perhaps the best idea is to squash commits before merge. 
+
+### Labeling convention
+
+[1] [StandardIssueLabels](https://github.com/wagenet/StandardIssueLabels#standardissuelabels) 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2021 Bisnode
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # opa-java-client
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.bisnode.opa/opa-java-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.bisnode.opa/opa-java-client) ![build](https://github.com/Bisnode/opa-java-client/workflows/build/badge.svg)
 
-OPA java client is a wrapper for OPA REST API. The goal was to create client that is lightweight and framework independent. It's built for current Bisnode needs, including:
+OPA java client is a wrapper for [OPA REST API](https://www.openpolicyagent.org/docs/latest/rest-api/). The goal was to create client that is lightweight and framework independent. It's built for current Bisnode needs, including:
  - creating documents
  - creating policies
  - querying for documents
@@ -69,5 +69,6 @@ Available interface projections:
 Build process and dependency management is done using Gradle.
 Tests are written in spock.
 
+## Contribution
 
-
+Interested in contributing? Please, start by reading [this document](https://github.com/Bisnode/opa-java-client/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
I prepared something, but let's discuss the details ;) 

This changes brings standardization among Bisnode's repositories. 
I thought about `SECURITY.md` but instead I enclosed information in Contributing.
Changes applied here will be propagated to other repositories.

Signed-off-by: lukkad <lukasz.kadalski@bisnode.com>