### PR TITLE
Use mailto: for all email links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[this email](nights-watch@bisnode.com).
+[this email](mailto:nights-watch@bisnode.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,15 +41,15 @@ For something that is bigger than a few line fix:
 
 # How to report a bug
 
-If you find a security vulnerability, do NOT open an issue. Email [maintainers](nights-watch@bisnode.com) instead.
+If you find a security vulnerability, do NOT open an issue. Email [maintainers](mailto:nights-watch@bisnode.com) instead.
 
 
-Any security issues should be submitted directly to [maintainers](nights-watch@bisnode.com)
+Any security issues should be submitted directly to [maintainers](mailto:nights-watch@bisnode.com)
 In order to determine whether you are dealing with a security issue, ask yourself these two questions:
 * Can I access something that's not mine, or something I shouldn't have access to?
 * Can I disable something for other people?
 
-If the answer to either of those two questions are "yes", then you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, just [email us](nights-watch@bisnode.com).
+If the answer to either of those two questions are "yes", then you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, just [email us](mailto:nights-watch@bisnode.com).
  
 When filing an issue, make sure to answer these five questions:
 


### PR DESCRIPTION
Since the email links do not start with `mailto:` they are treated as relative links.  Adding this allows the links to easily be opened in your default mail client.