### PR TITLE
Allows for configuring a custom ObjectMapper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation("org.codehaus.groovy:groovy-all:2.5.15")
     testImplementation("org.spockframework:spock-core:1.3-groovy-2.5")
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.31.0")
+    testImplementation("net.bytebuddy:byte-buddy:1.12.12")
 }
 
 repositories {

--- a/src/main/java/com/bisnode/opa/client/OpaClient.java
+++ b/src/main/java/com/bisnode/opa/client/OpaClient.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpClient;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Opa client featuring {@link OpaDataApi}, {@link OpaQueryApi} and {@link OpaPolicyApi}
@@ -83,7 +84,7 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
             return this;
         }
 
-        public Builder objectMapperConfiguration(ObjectMapper objectMapper) {
+        public Builder objectMapper(ObjectMapper objectMapper) {
             this.objectMapper = objectMapper;
             return this;
         }
@@ -93,9 +94,8 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
             HttpClient httpClient = HttpClient.newBuilder()
                     .version(opaConfiguration.getHttpVersion())
                     .build();
-            if(this.objectMapper == null) {
-                this.objectMapper = ObjectMapperFactory.getInstance().create();
-            }
+            ObjectMapper objectMapper = Optional.ofNullable(this.objectMapper)
+                    .orElseGet(ObjectMapperFactory.getInstance()::create);
             OpaRestClient opaRestClient = new OpaRestClient(opaConfiguration, httpClient, objectMapper);
             return new OpaClient(new OpaQueryClient(opaRestClient), new OpaDataClient(opaRestClient), new OpaPolicyClient(opaRestClient));
         }

--- a/src/main/java/com/bisnode/opa/client/OpaClient.java
+++ b/src/main/java/com/bisnode/opa/client/OpaClient.java
@@ -12,6 +12,7 @@ import com.bisnode.opa.client.query.OpaQueryClient;
 import com.bisnode.opa.client.query.QueryForDocumentRequest;
 import com.bisnode.opa.client.rest.ObjectMapperFactory;
 import com.bisnode.opa.client.rest.OpaRestClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.lang.reflect.ParameterizedType;
 import java.net.http.HttpClient;
@@ -72,6 +73,7 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
      */
     public static class Builder {
         private OpaConfiguration opaConfiguration;
+        private ObjectMapper objectMapper;
 
         /**
          * @param url URL including protocol and port
@@ -81,12 +83,20 @@ public class OpaClient implements OpaQueryApi, OpaDataApi, OpaPolicyApi {
             return this;
         }
 
+        public Builder objectMapperConfiguration(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
         public OpaClient build() {
             Objects.requireNonNull(opaConfiguration, "build() called without opaConfiguration provided");
             HttpClient httpClient = HttpClient.newBuilder()
                     .version(opaConfiguration.getHttpVersion())
                     .build();
-            OpaRestClient opaRestClient = new OpaRestClient(opaConfiguration, httpClient, ObjectMapperFactory.getInstance().create());
+            if(this.objectMapper == null) {
+                this.objectMapper = ObjectMapperFactory.getInstance().create();
+            }
+            OpaRestClient opaRestClient = new OpaRestClient(opaConfiguration, httpClient, objectMapper);
             return new OpaClient(new OpaQueryClient(opaRestClient), new OpaDataClient(opaRestClient), new OpaPolicyClient(opaRestClient));
         }
     }

--- a/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
+++ b/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
@@ -27,7 +27,7 @@ class OpaClientBuilderSpec extends Specification {
         wireMockServer.stop()
     }
 
-    def 'configure OpaClient with custom ObjectMapper'() {
+    def 'should configure OpaClient with custom ObjectMapper'() {
 
         given:
         def objectMapper = Spy(ObjectMapper)
@@ -42,7 +42,7 @@ class OpaClientBuilderSpec extends Specification {
                                 .withBody('{"result": {"authorized": true}}')))
         def opaClient = OpaClient.builder()
                 .opaConfiguration(url)
-                .objectMapperConfiguration(objectMapper)
+                .objectMapper(objectMapper)
                 .build();
 
         when:

--- a/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
+++ b/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
@@ -1,0 +1,54 @@
+package com.bisnode.opa.client
+
+
+import com.bisnode.opa.client.query.QueryForDocumentRequest
+import com.bisnode.opa.client.rest.ContentType
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static com.bisnode.opa.client.rest.ContentType.Values.APPLICATION_JSON
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class OpaClientBuilderSpec extends Specification {
+
+    private static int PORT = 8181
+    private static String url = "http://localhost:$PORT"
+
+    @Shared
+    private WireMockServer wireMockServer = new WireMockServer(PORT)
+
+    def setupSpec() {
+        wireMockServer.start()
+    }
+
+    def cleanupSpec() {
+        wireMockServer.stop()
+    }
+
+    def 'configure OpaClient with custom ObjectMapper'() {
+
+        given:
+        def objectMapper = Spy(ObjectMapper)
+        def path = 'someDocument'
+        def endpoint = "/v1/data/$path"
+        wireMockServer
+                .stubFor(post(urlEqualTo(endpoint))
+                        .withHeader(ContentType.HEADER_NAME, equalTo(APPLICATION_JSON))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader(ContentType.HEADER_NAME, APPLICATION_JSON)
+                                .withBody('{"result": {"authorized": true}}')))
+        def opaClient = OpaClient.builder()
+                .opaConfiguration(url)
+                .objectMapperConfiguration(objectMapper)
+                .build();
+
+        when:
+        opaClient.queryForDocument(new QueryForDocumentRequest([shouldPass: true], path), Object.class)
+
+        then:
+        1 * objectMapper.writeValueAsString(_)
+    }
+}

--- a/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
+++ b/src/test/groovy/com/bisnode/opa/client/OpaClientBuilderSpec.groovy
@@ -51,4 +51,28 @@ class OpaClientBuilderSpec extends Specification {
         then:
         1 * objectMapper.writeValueAsString(_)
     }
+
+    def 'should revert to default ObjectMapper if null ObjectMapper supplied'() {
+        given:
+        def path = 'someDocument'
+        def endpoint = "/v1/data/$path"
+        wireMockServer
+                .stubFor(post(urlEqualTo(endpoint))
+                        .withHeader(ContentType.HEADER_NAME, equalTo(APPLICATION_JSON))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader(ContentType.HEADER_NAME, APPLICATION_JSON)
+                                .withBody('{"result": {"authorized": true}}')))
+        def opaClient = OpaClient.builder()
+                .opaConfiguration(url)
+                .objectMapper(null)
+                .build();
+
+        when:
+        def result = opaClient.queryForDocument(new QueryForDocumentRequest([shouldPass: true], path), Map.class)
+
+        then:
+        result != null
+        result.get("authorized") == true
+    }
 }


### PR DESCRIPTION
This change modifies the OpaClient builder to optionally take a custom
ObjectMapper.

As discussed in #46 

Let me know if any changes are required. 